### PR TITLE
Added CRISPR DNA repair outcomes dataset

### DIFF
--- a/tdc/label_name_list.py
+++ b/tdc/label_name_list.py
@@ -272,6 +272,9 @@ TAP_targets = ['CDR_Length', 'PSH', 'PPC', 'PNC', 'SFvCSP']
 drugcomb_targets = ['CSS', 'Synergy_ZIP', 'Synergy_Bliss',
                     'Synergy_Loewe','Synergy_HSA']
 
+leenay_targets = ['Fraction_Insertions', 'Avg_Insertion_Length', 'Avg_Deletion_Length',
+       'Indel_Diversity', 'Fraction_Frameshifts']
+
 dataset2target_lists = {'qm7b': QM7_targets,
                             'qm8': QM8_targets,
                             'qm9': QM9_targets,

--- a/tdc/label_name_list.py
+++ b/tdc/label_name_list.py
@@ -280,4 +280,5 @@ dataset2target_lists = {'qm7b': QM7_targets,
                             'qm9': QM9_targets,
                             'tap': TAP_targets,
                             'toxcast': ToxCast_targets,
-                            'tox21': Tox21_targets}
+                            'tox21': Tox21_targets,
+                            'leenay': leenay_targets}

--- a/tdc/metadata.py
+++ b/tdc/metadata.py
@@ -273,7 +273,7 @@ dataset_names = {"Toxicity": toxicity_dataset_names,
 				"Yields": yield_dataset_names, 
 				"Catalyst": catalyst_dataset_names, 
 				"CompoundLibrary": compound_library_names,
-				"BioKG": biokg_library_names
+				"BioKG": biokg_library_names,
 				"CRISPROutcome": crisproutcome_dataset_names
 				}
 
@@ -363,8 +363,8 @@ name2type = {'toxcast': 'tab',
  'clearance_hepatocyte_az': 'tab',
  'half_life_obach': 'tab',
  'ld50_zhu': 'tab',
- 'vdss_lombardo': 'tab'
- 'leenay':'csv'}
+ 'vdss_lombardo': 'tab',
+ 'leenay':'tab'}
 
 name2id = {'bbb_adenot': 4259565,
  'bbb_martins': 4259566,
@@ -443,8 +443,8 @@ name2id = {'bbb_adenot': 4259565,
  'clearance_hepatocyte_az': 4266187,
  'ld50_zhu': 4267146,
  'half_life_obach': 4266799,
- 'vdss_lombardo': 4267387
- 'leenay':00000 } ## TODO:update dataverse ID
+ 'vdss_lombardo': 4267387,
+ 'leenay':4279966 }
 
 oracle2type = {'drd2': 'pkl', 
 			   'jnk3': 'pkl', 

--- a/tdc/metadata.py
+++ b/tdc/metadata.py
@@ -64,6 +64,8 @@ mti_dataset_names = ['mirtarbase']
 
 gda_dataset_names = ['disgenet']
 
+crisproutcome_dataset_names = ['leenay']
+
 drugres_dataset_names = ['gdsc1', 'gdsc2']
 
 drugsyn_dataset_names = ['oncopolypharmacology', 'drugcomb_nci60']
@@ -222,7 +224,8 @@ category_names = {'single_pred': ["Tox",
 									"Develop",
 									"QM",
 									"Paratope",
-									"Yields"],
+									"Yields",
+									"CRISPROutcome"],
 				'multi_pred': ["DTI",
 								"PPI",
 								"DDI",
@@ -271,6 +274,7 @@ dataset_names = {"Toxicity": toxicity_dataset_names,
 				"Catalyst": catalyst_dataset_names, 
 				"CompoundLibrary": compound_library_names,
 				"BioKG": biokg_library_names
+				"CRISPROutcome": crisproutcome_dataset_names
 				}
 
 benchmark_names = {"admet_group": admet_benchmark}
@@ -360,7 +364,7 @@ name2type = {'toxcast': 'tab',
  'half_life_obach': 'tab',
  'ld50_zhu': 'tab',
  'vdss_lombardo': 'tab'
- }
+ 'leenay':'csv'}
 
 name2id = {'bbb_adenot': 4259565,
  'bbb_martins': 4259566,
@@ -440,7 +444,7 @@ name2id = {'bbb_adenot': 4259565,
  'ld50_zhu': 4267146,
  'half_life_obach': 4266799,
  'vdss_lombardo': 4267387
- }
+ 'leenay':00000 } ## TODO:update dataverse ID
 
 oracle2type = {'drd2': 'pkl', 
 			   'jnk3': 'pkl', 

--- a/tdc/single_pred/dataloader.py
+++ b/tdc/single_pred/dataloader.py
@@ -219,3 +219,29 @@ class Yields(single_pred_dataset.DataLoader):
         if print_stats:
             self.print_stats()
         print('Done!', flush = True, file = sys.stderr)
+
+class CRISPROutcome(single_pred_dataset.DataLoader):
+    """DNA repair outcomes following a CRISPR experiment.
+
+    Parameters
+    ----------
+    name : str
+        Description of the variable.
+
+    path : str, optional (default="data")
+        Description of the variable.
+
+    label_name : str, optional (default=None)
+        Description of the variable.
+
+    print_stats : bool, optional (default=True)
+        Description of the variable.
+    """
+
+    def __init__(self, name, path='./data', label_name=None, print_stats=False):
+        super().__init__(name, path, label_name, print_stats,
+                         dataset_names=dataset_names["CRISPROutcome"])
+        self.entity1_name = 'GuideSeq'
+        if print_stats:
+            self.print_stats()
+        print('Done!', flush = True, file = sys.stderr)


### PR DESCRIPTION
**Dataset Description:** Primary T cells are a promising cell type for therapeutic genome editing, as they can be engineered efficiently ex vivo and transferred to patients. This dataset consists of the DNA repair outcomes of CRISPR-CAS9 knockout experiments on primary CD4+ T cells drawn from 15 donors. For each of the 1,521 unique genomic locations from 553 genes, we provide the 20-nucleotide guide sequence along with the 3-nucletoide PAM sequence. 

5 repair outcomes are included for prediction: fraction of indel reads with an insertion, average insertion length, average deletion length, indel diversity, fraction of repair outcomes with a frameshift.

**Task Description**: Given a DNA sequence, predict the repair outcomes of a CRISPR-CAS9 knockout experiment. 

**Dataset Statistics**: 1,521 DNA sequences (guide+PAM) with 5 repair outcomes for each measured across different donor populations of primary T cells

**Dataset Split**: Random Split

**References**: Leenay, Ryan T., et al. "Large dataset enables prediction of repair after CRISPR–Cas9 editing in primary T cells." Nature biotechnology 37.9 (2019): 1034-1037.

**License**: CC BY 3.0.