### PR TITLE
Add evaluate_many to Benchmark

### DIFF
--- a/tdc/benchmark.py
+++ b/tdc/benchmark.py
@@ -149,3 +149,29 @@ class BenchmarkGroup:
 			metric_dict = bm_metric_names[self.name]
 			evaluator = eval('Evaluator(name = \'' + metric_dict[data_name] + '\')')
 			return {metric_dict[data_name]: round(evaluator(true, pred), 3)}
+
+	def evaluate_many(self, preds):
+		"""
+		:param preds: list of dict<str dataset_name: list of float>
+		:return: dict<dataset_name: [mean_metric_result, std_metric_result]
+
+		This function returns the data in a format needed to submit to the Leaderboard
+		"""
+		if len(preds) != 5:
+			return ValueError("Must have Five Predictions For Leaderboard Submission")
+		individual_results = []
+		for pred in preds:
+			retval = self.evaluate(pred)
+			individual_results.append(retval)
+
+		given_dataset_names = list(individual_results[0].keys())
+		aggregated_results = {}
+		for dataset_name in given_dataset_names:
+			my_results = []
+			for individual_result in individual_results:
+				my_result = list(individual_result[dataset_name].values())[0]
+				my_results.append(my_result)
+			u = np.mean(my_results)
+			std = np.std(my_results)
+			aggregated_results[dataset_name] = [u, std]
+		return aggregated_results

--- a/tdc/test/test_benchmark.py
+++ b/tdc/test/test_benchmark.py
@@ -1,0 +1,57 @@
+import unittest
+import shutil
+import numpy as np
+import random
+from tdc.benchmark import BenchmarkGroup
+
+
+def is_classification(values):
+    value_set = set(values)
+    if len(value_set) == 2:
+        return True
+    return False
+
+
+class TestBenchmarkGroup(unittest.TestCase):
+    def setUp(self):
+        self.group = BenchmarkGroup(name='ADMET_Group', path='data/')
+
+    def tearDown(self) -> None:
+        shutil.rmtree('data', ignore_errors=True)
+
+    def test_ADME_mean_prediction(self):
+        predictions = {}
+        num_datasets = 0
+        for my_group in self.group:
+            num_datasets += 1
+            name = my_group['name']
+            test = my_group['test']
+            mean_val = np.mean(test['Y'])
+            predictions[name] = [mean_val] * len(test)
+
+        results = self.group.evaluate(predictions)
+        self.assertEqual(num_datasets, len(results))
+        for my_group in self.group:
+            self.assertTrue(my_group['name'] in results)
+
+    def test_ADME_evaluate_many(self):
+        prediction_list = []
+        num_datasets = 0
+        for random_seed in range(5):
+            predictions = {}
+            for my_group in self.group:
+                num_datasets += 1
+                name = my_group['name']
+                test = my_group['test']
+                predictions[name] = test['Y']
+            prediction_list.append(predictions)
+
+        results = self.group.evaluate_many(prediction_list)
+        for ds_name, metrics in results.items():
+            self.assertEqual(len(metrics), 2)
+            u, std = metrics
+            self.assertTrue(u in (1, 0))  # A perfect score for all metrics is 1 or 0
+            self.assertEqual(0, std)
+
+        for my_group in self.group:
+            self.assertTrue(my_group['name'] in results)

--- a/tdc/test/test_benchmark.py
+++ b/tdc/test/test_benchmark.py
@@ -36,11 +36,9 @@ class TestBenchmarkGroup(unittest.TestCase):
 
     def test_ADME_evaluate_many(self):
         prediction_list = []
-        num_datasets = 0
         for random_seed in range(5):
             predictions = {}
             for my_group in self.group:
-                num_datasets += 1
                 name = my_group['name']
                 test = my_group['test']
                 predictions[name] = test['Y']


### PR DESCRIPTION
Right now there is a way to evaluate a single random seed for a Benchmark group but no way to actually run the calculations needed to submit an entry here https://docs.google.com/forms/d/e/1FAIpQLSeAs_PhRyT9iqPc4WX0HOUFI3WdQNATKt7kZ7ztzf5DKaolkA/viewform.  This PR adds that functionality.  It is not currently tested with multi-class classification methods.