### PR TITLE
feat: Add interface for multi-instance splitting (closes #126)

### DIFF
--- a/tdc/multi_pred/bi_pred_dataset.py
+++ b/tdc/multi_pred/bi_pred_dataset.py
@@ -17,6 +17,7 @@ from ..utils import dataset2target_lists, \
                     install,\
                     create_fold,\
                     create_fold_setting_cold,\
+                    create_fold_setting_cold_multi,\
                     create_combination_split,\
                     create_fold_time,\
                     print_sys
@@ -148,7 +149,8 @@ class DataLoader(base_dataset.DataLoader):
                 random seed, defaults to '42'
             frac (list, optional): 
                 train/val/test split fractions, defaults to '[0.7, 0.1, 0.2]'
-            column_name (None, optional): Description
+            column_name (Optional[Union[str, List[str]]]): Optional column name(s) to
+                split on for cold splits. Defaults to None.
             time_column (None, optional): Description
         
         Returns:
@@ -169,6 +171,8 @@ class DataLoader(base_dataset.DataLoader):
         elif (column_name is not None) and (column_name in df.columns.values):
             if method == 'cold_split':
                 return create_fold_setting_cold(df, seed, frac, column_name)
+        elif method == 'cold_split_multi':
+            return create_fold_setting_cold_multi(df, seed, frac, column_name)
         elif method == 'combination':
             return create_combination_split(df, seed, frac)
         elif method == 'time':

--- a/tdc/multi_pred/bi_pred_dataset.py
+++ b/tdc/multi_pred/bi_pred_dataset.py
@@ -17,7 +17,6 @@ from ..utils import dataset2target_lists, \
                     install,\
                     create_fold,\
                     create_fold_setting_cold,\
-                    create_fold_setting_cold_multi,\
                     create_combination_split,\
                     create_fold_time,\
                     print_sys
@@ -139,28 +138,32 @@ class DataLoader(base_dataset.DataLoader):
         print_sys('--------------------------')
     
     def get_split(self, method='random', seed=42,
-                  frac=[0.7, 0.1, 0.2], column_name=None, time_column = None):
+                  frac=[0.7, 0.1, 0.2], column_name=None, time_column=None):
         """split dataset into train/validation/test. 
-        
+
         Args:
-            method (str, optional): 
+            method (str, optional):
                 split method, the default value is 'random'
-            seed (int, optional): 
+            seed (int, optional):
                 random seed, defaults to '42'
-            frac (list, optional): 
+            frac (list, optional):
                 train/val/test split fractions, defaults to '[0.7, 0.1, 0.2]'
             column_name (Optional[Union[str, List[str]]]): Optional column name(s) to
                 split on for cold splits. Defaults to None.
             time_column (None, optional): Description
-        
+
         Returns:
-            dict: a dictionary with three keys ('train', 'valid', 'test'), each value is a pandas dataframe object of the splitted dataset 
-        
+            dict: a dictionary with three keys ('train', 'valid', 'test'), each value
+            is a pandas dataframe object of the splitted dataset.
+
         Raises:
-            AttributeError: the input split method is not available. 
+            AttributeError: the input split method is not available.
 
         """
         df = self.get_data(format='df')
+
+        if isinstance(column_name, str):
+            column_name = [column_name]
 
         if method == 'random':
             return create_fold(df, seed, frac)
@@ -168,11 +171,16 @@ class DataLoader(base_dataset.DataLoader):
             return create_fold_setting_cold(df, seed, frac, self.entity1_name)
         elif method == 'cold_' + self.entity2_name.lower():
             return create_fold_setting_cold(df, seed, frac, self.entity2_name)
-        elif (column_name is not None) and (column_name in df.columns.values):
-            if method == 'cold_split':
-                return create_fold_setting_cold(df, seed, frac, column_name)
-        elif method == 'cold_split_multi':
-            return create_fold_setting_cold_multi(df, seed, frac, column_name)
+        elif method == 'cold_split':
+            if (
+                column_name is None or
+                not all(list(map(lambda x: x in df.columns.values, column_name)))
+            ):
+                raise AttributeError(
+                    "For cold_split, please provide one or multiple column names "
+                    "that are contained in the dataframe."
+                )
+            return create_fold_setting_cold(df, seed, frac, column_name)
         elif method == 'combination':
             return create_combination_split(df, seed, frac)
         elif method == 'time':
@@ -181,9 +189,9 @@ class DataLoader(base_dataset.DataLoader):
             return create_fold_time(df, frac, time_column)
 
         else:
-            raise AttributeError("Please select from random_split, "
-                                 "or cold_split. If cold split, "
-                                 "please specify the column name!")
+            raise AttributeError(
+                "Please select method from random, time, combination or cold_split."
+            )
 
     def neg_sample(self, frac=1):
         """negative sampling 

--- a/tdc/test/dev_tests/utils_tests/test_splits.py
+++ b/tdc/test/dev_tests/utils_tests/test_splits.py
@@ -21,13 +21,11 @@ class TestFunctions(unittest.TestCase):
         pass
 
     def test_random_split(self):
-        print('started random')
         from tdc.single_pred import ADME
         data = ADME(name = 'Caco2_Wang')
         split = data.get_split(method = 'random')
 
     def test_scaffold_split(self):
-        print('started scaffold')
         ## requires RDKit
         from tdc.single_pred import ADME
         data = ADME(name='Caco2_Wang')

--- a/tdc/test/dev_tests/utils_tests/test_splits.py
+++ b/tdc/test/dev_tests/utils_tests/test_splits.py
@@ -21,32 +21,47 @@ class TestFunctions(unittest.TestCase):
         pass
 
     def test_random_split(self):
+        print('started random')
         from tdc.single_pred import ADME
         data = ADME(name = 'Caco2_Wang')
         split = data.get_split(method = 'random')
 
     def test_scaffold_split(self):
+        print('started scaffold')
         ## requires RDKit
         from tdc.single_pred import ADME
         data = ADME(name='Caco2_Wang')
         split = data.get_split(method='scaffold')
 
-    def cold_start_split(self):
+    def test_cold_start_split(self):
         from tdc.multi_pred import DTI
         data = DTI(name = 'DAVIS')
         split = data.get_split(method = 'cold_split', column_name = 'Drug')
 
-    def combination_split(self):
+        self.assertEqual(0, len(set(split['train']['Drug']).intersection(set(split['test']['Drug']))))
+        self.assertEqual(0, len(set(split['valid']['Drug']).intersection(set(split['test']['Drug']))))
+        self.assertEqual(0, len(set(split['train']['Drug']).intersection(set(split['valid']['Drug']))))
+
+        multi_split = data.get_split(method='cold_split', column_name=['Drug_ID', 'Target_ID'])
+        for entity in ['Drug_ID', 'Target_ID']:
+            train_entity = set(multi_split['train'][entity])
+            valid_entity = set(multi_split['valid'][entity])
+            test_entity = set(multi_split['test'][entity])
+            self.assertEqual(0, len(train_entity.intersection(valid_entity)))
+            self.assertEqual(0, len(train_entity.intersection(test_entity)))
+            self.assertEqual(0, len(valid_entity.intersection(test_entity)))
+
+    def test_combination_split(self):
         from tdc.multi_pred import DrugSyn
         data = DrugSyn(name = 'DrugComb')
         split = data.get_split(method = 'combination')
 
-    def time_split(self):
+    def test_time_split(self):
         from tdc.multi_pred import DTI
         data = DTI(name = 'BindingDB_Patent')
         split = data.get_split(method = 'time', time_column = 'Year')
 
-    def tearDown(self):
+    def test_tearDown(self):
         print(os.getcwd())
 
         if os.path.exists(os.path.join(os.getcwd(), "data")):

--- a/tdc/utils/__init__.py
+++ b/tdc/utils/__init__.py
@@ -9,7 +9,6 @@ from .load import distribution_dataset_load, \
 					bm_group_load
 from .split import create_fold,\
 					create_fold_setting_cold,\
-					create_fold_setting_cold_multi,\
 					create_combination_split,\
 					create_fold_time,\
 					create_scaffold_split,\

--- a/tdc/utils/__init__.py
+++ b/tdc/utils/__init__.py
@@ -9,6 +9,7 @@ from .load import distribution_dataset_load, \
 					bm_group_load
 from .split import create_fold,\
 					create_fold_setting_cold,\
+					create_fold_setting_cold_multi,\
 					create_combination_split,\
 					create_fold_time,\
 					create_scaffold_split,\

--- a/tdc/utils/split.py
+++ b/tdc/utils/split.py
@@ -27,8 +27,8 @@ def create_fold(df, fold_seed, frac):
 			'test': test.reset_index(drop = True)}
 
 def create_fold_setting_cold(df, fold_seed, frac, entities):
-	"""create cold-split where given one or multiple columns, it first split based on
-	entities in the columns and then map all associated data points to each split
+	"""create cold-split where given one or multiple columns, it first splits based on
+	entities in the columns and then maps all associated data points to the partition
 
 	Args:
 		df (pd.DataFrame): dataset dataframe
@@ -49,8 +49,7 @@ def create_fold_setting_cold(df, fold_seed, frac, entities):
 	test_entity_instances = [
 		df[e].drop_duplicates().sample(
 			frac=test_frac, replace=False, random_state=fold_seed
-		).values
-		for e in entities
+		).values for e in entities
 	]
 
 	# Select samples where all entities are in the test set
@@ -64,10 +63,6 @@ def create_fold_setting_cold(df, fold_seed, frac, entities):
 			'less stringent splitting strategy.'
 		)
 
-	# Verify that the split was correct
-	for i, e in enumerate(entities):
-		assert all(test[e].isin(test_entity_instances[i])), f'Test samples contain incorrect entity in {e}'
-
 	# Proceed with validation data
 	train_val = df.copy()
 	for i, e in enumerate(entities):
@@ -76,8 +71,7 @@ def create_fold_setting_cold(df, fold_seed, frac, entities):
 	val_entity_instances = [
 		train_val[e].drop_duplicates().sample(
 			frac=val_frac/(1-test_frac), replace=False, random_state=fold_seed
-		).values
-		for e in entities
+		).values for e in entities
 	]
 	val = train_val.copy()
 	for entity, instances in zip(entities, val_entity_instances):
@@ -88,10 +82,6 @@ def create_fold_setting_cold(df, fold_seed, frac, entities):
 			'No validation samples found. Try another seed, increasing the test frac '
 			'or a less stringent splitting strategy.'
 		)
-
-	# Verify that the split was correct
-	for i,e in enumerate(entities):
-		assert all(val[e].isin(val_entity_instances[i])), f'Val samples contain incorrect entity in {e}'
 
 	train = train_val.copy()
 	for i,e in enumerate(entities):

--- a/tdc/utils/split.py
+++ b/tdc/utils/split.py
@@ -26,47 +26,23 @@ def create_fold(df, fold_seed, frac):
 			'valid': val.reset_index(drop = True),
 			'test': test.reset_index(drop = True)}
 
-def create_fold_setting_cold(df, fold_seed, frac, entity):
-	"""create cold-split where given a column, it first split based on entities in the column and then map all associated data points to each split
-	
-	Args:
-	    df (pd.DataFrame): dataset dataframe
-	    fold_seed (int): the random seed
-	    frac (list): a list of train/valid/test fractions
-	    entity (str): the "cold" entity to first split on
-	
-	Returns:
-	    dict: a dictionary of splitted dataframes, where keys are train/valid/test and values correspond to each dataframe
-	"""
-	train_frac, val_frac, test_frac = frac
-	gene_drop = df[entity].drop_duplicates().sample(frac = test_frac, replace = False, random_state = fold_seed).values
-
-	test = df[df[entity].isin(gene_drop)]
-
-	train_val = df[~df[entity].isin(gene_drop)]
-
-	gene_drop_val = train_val[entity].drop_duplicates().sample(frac = val_frac/(1-test_frac), replace = False, random_state = fold_seed).values
-	val = train_val[train_val[entity].isin(gene_drop_val)]
-	train = train_val[~train_val[entity].isin(gene_drop_val)]
-
-	return {'train': train.reset_index(drop = True),
-			'valid': val.reset_index(drop = True),
-			'test': test.reset_index(drop = True)}
-
-
-def create_fold_setting_cold_multi(df, fold_seed, frac, entities):
-	"""create cold-split where given a column, it first split based on entities in the
-	column and then map all associated data points to each split
+def create_fold_setting_cold(df, fold_seed, frac, entities):
+	"""create cold-split where given one or multiple columns, it first split based on
+	entities in the columns and then map all associated data points to each split
 
 	Args:
-	    df (pd.DataFrame): dataset dataframe
-	    fold_seed (int): the random seed
-	    frac (list): a list of train/valid/test fractions
-	    entities (list): a list of "cold" entities on which the split is done
+		df (pd.DataFrame): dataset dataframe
+		fold_seed (int): the random seed
+		frac (list): a list of train/valid/test fractions
+		entities (Union[str, List[str]]): either a single "cold" entity or a list of
+			"cold" entities on which the split is done
 
 	Returns:
-	    dict: a dictionary of splitted dataframes, where keys are train/valid/test and values correspond to each dataframe
+		dict: a dictionary of splitted dataframes, where keys are train/valid/test and values correspond to each dataframe
 	"""
+	if isinstance(entities, str):
+		entities = [entities]
+
 	train_frac, val_frac, test_frac = frac
 
 	# For each entity, sample the instances belonging to the test datasets
@@ -84,22 +60,17 @@ def create_fold_setting_cold_multi(df, fold_seed, frac, entities):
 
 	if len(test) == 0:
 		raise ValueError(
-			'No test samples found. Try increasing the test frac or a less stringent '
-			'splitting strategy.'
+			'No test samples found. Try another seed, increasing the test frac or a '
+			'less stringent splitting strategy.'
 		)
 
 	# Verify that the split was correct
-	for i,e in enumerate(entities):
+	for i, e in enumerate(entities):
 		assert all(test[e].isin(test_entity_instances[i])), f'Test samples contain incorrect entity in {e}'
-
-	# DEBUGGING
-	print(f'Assigned {len(test)} samples to testing')
-	for e in entities:
-		print(f'{e} has {len(test[e].unique())} entities')
 
 	# Proceed with validation data
 	train_val = df.copy()
-	for i,e in enumerate(entities):
+	for i, e in enumerate(entities):
 		train_val = train_val[~train_val[e].isin(test_entity_instances[i])]
 
 	val_entity_instances = [
@@ -114,25 +85,17 @@ def create_fold_setting_cold_multi(df, fold_seed, frac, entities):
 
 	if len(val) == 0:
 		raise ValueError(
-			'No validation samples found. Try increasing the test frac or a less '
-			'stringent splitting strategy.'
+			'No validation samples found. Try another seed, increasing the test frac '
+			'or a less stringent splitting strategy.'
 		)
 
 	# Verify that the split was correct
 	for i,e in enumerate(entities):
 		assert all(val[e].isin(val_entity_instances[i])), f'Val samples contain incorrect entity in {e}'
 
-	print(f'Assigned {len(val)} samples to validation')
-	for e in entities:
-		print(f'{e} has {len(val[e].unique())} entities')
-
 	train = train_val.copy()
 	for i,e in enumerate(entities):
 		train = train[~train[e].isin(val_entity_instances[i])]
-
-	print(f'Assigned {len(train)} samples to testing')
-	for e in entities:
-		print(f'{e} has {len(train[e].unique())} entities')
 
 	return {'train': train.reset_index(drop = True),
 			'valid': val.reset_index(drop = True),


### PR DESCRIPTION
Addressing #126 (support for multi-instance splitting). 
This is a draft PR, please give some feedback @kexinhuang12345 

**Done:**
Following your suggestion, I implemented a method called `create_fold_setting_cold_multi` that splits on multiple instance. I tried to follow the package conventions in coding style. The code logic is to iterate over all entities on which the split should be done (e.g., `['Drug_ID', 'Cell Line_ID']`) and randomly assign entity-instances to test. The test-set is created by selecting samples where **all** entity instances belong to test. This is then repeated for validation.
The proposed method is strictly more powerful than the current `create_fold_setting_cold`. Indeed, if a single entity is passed for splitting the result is always identical. I verified like this for multiple configurations.
```py
folds_1 = create_fold_setting_cold_multi(df, 42, [0.8, 0.1, 0.1], entities=['Drug_ID'])
folds_2 = create_fold_setting_cold_multi(df, 42, [0.8, 0.1, 0.1], entity='Drug_ID')

for a,b in zip(folds_1.values(), folds_1.values()):
    assert all(a==b)

```
Therefore, I wanted to suggest to replace the current `create_fold_setting_cold` with the body of the new `create_fold_setting_cold_multi`. This would be perfectly backwards compatible. The only difference would be that for the positional `entity` argument, instead of a `str` you could **also** pass a List of strings. The beauty of this solution is that it would avoid duplicate code snippets and require minimal updates in the existing codebase. Let me know what you think

**ToDo:**
- Decide whether `create_fold_setting_cold` is superseded by `create_fold_setting_cold_multi`
- Add an example to the docs
- unittests. Do you want to see some?
- Remove the print commands (I added them for debugging)

