### PR TITLE
New TCR-Epitope Binding Affinity Prediction Task

### DIFF
--- a/tdc/metadata.py
+++ b/tdc/metadata.py
@@ -144,7 +144,7 @@ yield_dataset_names = ['uspto_yields', 'buchwald-hartwig']
 
 catalyst_dataset_names = ['uspto_catalyst']
 
-tcr_epi_dataset_names = ['Weber']
+tcr_epi_dataset_names = ['weber']
 
 ####################################
 # generation
@@ -398,7 +398,7 @@ dataset_names = {"Tox": toxicity_dataset_names,
 				"CRISPROutcome": crisproutcome_dataset_names,
 				"test_single_pred": test_single_pred_dataset_names,
 				"test_multi_pred": test_multi_pred_dataset_names,
-				"TCR_Epitope_Binding": tcr_epi_dataset_names
+				"TCREpitopeBinding": tcr_epi_dataset_names
 				}
 
 benchmark_names = {"admet_group": admet_benchmark,
@@ -504,7 +504,7 @@ name2type = {'toxcast': 'tab',
  'test_single_pred': 'tab',
  'test_multi_pred': 'tab',
  'gdsc_gene_symbols': 'tab',
- 'Weber': 'tab'}
+ 'weber': 'tab'}
 
 name2id = {'bbb_adenot': 4259565,
  'bbb_martins': 4259566,
@@ -591,7 +591,7 @@ name2id = {'bbb_adenot': 4259565,
  'test_single_pred': 4832455,
  'test_multi_pred': 4832456,
  'gdsc_gene_symbols': 5255026,
- 'Weber': 5790963}
+ 'weber': 5790963}
 
 oracle2type = {'drd2': 'pkl', 
 			   'jnk3': 'pkl', 

--- a/tdc/metadata.py
+++ b/tdc/metadata.py
@@ -144,6 +144,7 @@ yield_dataset_names = ['uspto_yields', 'buchwald-hartwig']
 
 catalyst_dataset_names = ['uspto_catalyst']
 
+tcr_epi_dataset_names = ['Weber']
 
 ####################################
 # generation
@@ -358,7 +359,8 @@ category_names = {'single_pred': ["Tox",
 								"DrugSyn",
 								"MTI",
 								"GDA",
-								"Catalyst"],
+								"Catalyst",
+								"TCR_Epitope_Binding"],
 				'generation': ["RetroSyn",
 								"Reaction",
 								"MolGen"
@@ -395,7 +397,8 @@ dataset_names = {"Tox": toxicity_dataset_names,
 				"Catalyst": catalyst_dataset_names, 
 				"CRISPROutcome": crisproutcome_dataset_names,
 				"test_single_pred": test_single_pred_dataset_names,
-				"test_multi_pred": test_multi_pred_dataset_names
+				"test_multi_pred": test_multi_pred_dataset_names,
+				"TCR_Epitope_Binding": tcr_epi_dataset_names
 				}
 
 benchmark_names = {"admet_group": admet_benchmark,
@@ -500,7 +503,8 @@ name2type = {'toxcast': 'tab',
  'leenay':'tab',
  'test_single_pred': 'tab',
  'test_multi_pred': 'tab',
- 'gdsc_gene_symbols': 'tab'}
+ 'gdsc_gene_symbols': 'tab',
+ 'Weber': 'tab'}
 
 name2id = {'bbb_adenot': 4259565,
  'bbb_martins': 4259566,
@@ -586,7 +590,8 @@ name2id = {'bbb_adenot': 4259565,
  'leenay':4279966,
  'test_single_pred': 4832455,
  'test_multi_pred': 4832456,
- 'gdsc_gene_symbols': 5255026}
+ 'gdsc_gene_symbols': 5255026,
+ 'Weber': 5790963}
 
 oracle2type = {'drd2': 'pkl', 
 			   'jnk3': 'pkl', 

--- a/tdc/multi_pred/__init__.py
+++ b/tdc/multi_pred/__init__.py
@@ -9,3 +9,4 @@ from .mti import MTI
 from .peptidemhc import PeptideMHC
 from .ppi import PPI
 from .test_multi_pred import TestMultiPred
+from .tcr_epi import TCR_Epitope_Binding

--- a/tdc/multi_pred/__init__.py
+++ b/tdc/multi_pred/__init__.py
@@ -9,4 +9,4 @@ from .mti import MTI
 from .peptidemhc import PeptideMHC
 from .ppi import PPI
 from .test_multi_pred import TestMultiPred
-from .tcr_epi import TCR_Epitope_Binding
+from .tcr_epi import TCREpitopeBinding

--- a/tdc/multi_pred/tcr_epi.py
+++ b/tdc/multi_pred/tcr_epi.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+# Author: TDC Team
+# License: MIT
+
+import warnings
+warnings.filterwarnings("ignore")
+import sys
+
+from ..utils import print_sys
+from ..utils.load import download_wrapper, pd_load
+from . import bi_pred_dataset, multi_pred_dataset
+from ..metadata import dataset_names
+
+class TCR_Epitope_Binding(multi_pred_dataset.DataLoader):
+
+    """Data loader class to load datasets in T cell receptor (TCR) Specificity Prediction Task. 
+    More info: 
+
+    Task Description: Given the TCR and epitope sequence, predict binding probability.
+
+    Args:
+        name (str): the dataset name.
+        path (str, optional): 
+            The path to save the data file, defaults to './data'
+        label_name (str, optional): 
+            For multi-label dataset, specify the label name, defaults to None
+        print_stats (bool, optional): 
+            Whether to print basic statistics of the dataset, defaults to False
+
+    """
+    
+    def __init__(self, name, path='./data', print_stats=False):
+        """Create TCR Specificity Prediction dataloader object
+        """
+        super().__init__(name, path, print_stats,
+                         dataset_names=dataset_names["TCR_Epitope_Binding"])
+        self.entity1_name = 'TCR'
+        self.entity2_name = 'Epitope'
+
+        if print_stats:
+            self.print_stats()
+
+        print('Done!', flush=True, file=sys.stderr)

--- a/tdc/multi_pred/tcr_epi.py
+++ b/tdc/multi_pred/tcr_epi.py
@@ -11,7 +11,7 @@ from ..utils.load import download_wrapper, pd_load
 from . import bi_pred_dataset, multi_pred_dataset
 from ..metadata import dataset_names
 
-class TCR_Epitope_Binding(multi_pred_dataset.DataLoader):
+class TCREpitopeBinding(multi_pred_dataset.DataLoader):
 
     """Data loader class to load datasets in T cell receptor (TCR) Specificity Prediction Task. 
     More info: 
@@ -22,8 +22,6 @@ class TCR_Epitope_Binding(multi_pred_dataset.DataLoader):
         name (str): the dataset name.
         path (str, optional): 
             The path to save the data file, defaults to './data'
-        label_name (str, optional): 
-            For multi-label dataset, specify the label name, defaults to None
         print_stats (bool, optional): 
             Whether to print basic statistics of the dataset, defaults to False
 
@@ -33,7 +31,7 @@ class TCR_Epitope_Binding(multi_pred_dataset.DataLoader):
         """Create TCR Specificity Prediction dataloader object
         """
         super().__init__(name, path, print_stats,
-                         dataset_names=dataset_names["TCR_Epitope_Binding"])
+                         dataset_names=dataset_names["TCREpitopeBinding"])
         self.entity1_name = 'TCR'
         self.entity2_name = 'Epitope'
 

--- a/tdc/utils/label_name_list.py
+++ b/tdc/utils/label_name_list.py
@@ -280,6 +280,8 @@ leenay_targets = ['Fraction_Insertions', 'Avg_Insertion_Length', 'Avg_Deletion_L
 
 herg_central_targets = ['hERG_at_1uM', 'hERG_at_10uM', 'hERG_inhib']
 
+weber_targets = ['epitope_aa', 'epitope_smi', 'tcr', 'tcr_full']
+
 dataset2target_lists = {'qm7b': QM7_targets,
                             'qm8': QM8_targets,
                             'qm9': QM9_targets,
@@ -287,4 +289,5 @@ dataset2target_lists = {'qm7b': QM7_targets,
                             'toxcast': ToxCast_targets,
                             'tox21': Tox21_targets,
                             'leenay': leenay_targets,
-                            'herg_central': herg_central_targets}
+                            'herg_central': herg_central_targets,
+                            'Weber': weber_targets}

--- a/tdc/utils/label_name_list.py
+++ b/tdc/utils/label_name_list.py
@@ -280,8 +280,6 @@ leenay_targets = ['Fraction_Insertions', 'Avg_Insertion_Length', 'Avg_Deletion_L
 
 herg_central_targets = ['hERG_at_1uM', 'hERG_at_10uM', 'hERG_inhib']
 
-weber_targets = ['epitope_aa', 'epitope_smi', 'tcr', 'tcr_full']
-
 dataset2target_lists = {'qm7b': QM7_targets,
                             'qm8': QM8_targets,
                             'qm9': QM9_targets,
@@ -289,5 +287,4 @@ dataset2target_lists = {'qm7b': QM7_targets,
                             'toxcast': ToxCast_targets,
                             'tox21': Tox21_targets,
                             'leenay': leenay_targets,
-                            'herg_central': herg_central_targets,
-                            'Weber': weber_targets}
+                            'herg_central': herg_central_targets}


### PR DESCRIPTION
fixes #129. 

The new TCR-Epitope Binding Affinity Prediction Task can be used via: 

`from tdc.multi_pred import TCREpitopeBinding
data = TCREpitopeBinding(name = 'weber',  path = './data')`
 
The 'weber' dataset contains information about TCR full and cdr3 sequence, as well as epitope sequence as amino acids or smiles strings. 