### PR TITLE
added range_loagAUC as an evaluator

### DIFF
--- a/tdc/evaluator.py
+++ b/tdc/evaluator.py
@@ -193,7 +193,7 @@ class Evaluator:
 			from .chem_utils import fcd_distance
 			self.evaluator_func = fcd_distance
 		elif self.name == 'range_logAUC':
-			self.evaluator_func == range_logAUC()
+			self.evaluator_func = range_logAUC
 
 	def __call__(self, *args, **kwargs):
 		"""call the evaluator function on targets and predictions

--- a/tdc/evaluator.py
+++ b/tdc/evaluator.py
@@ -48,7 +48,7 @@ def range_logAUC(true_y, predicted_score, FPR_range=(0.001, 0.1)):
     This was used by previous methods [1] and the reason is that only a
     small percentage of samples can be selected for experimental tests in
     consideration of cost. This means only molecules with very high
-    predicted activity values can be worth testing, i.e., the decision
+    predicted score can be worth testing, i.e., the decision
     threshold is high. And the high decision threshold corresponds to the
     left side of the ROC curve, i.e., those FPRs with small values. Also,
     because the threshold cannot be predetermined, the area under the curve

--- a/tdc/evaluator.py
+++ b/tdc/evaluator.py
@@ -2,8 +2,6 @@ import pandas as pd
 import numpy as np
 import os, sys, json 
 import warnings
-from sklearn.metrics import auc, roc_curve
-import matplotlib.pyplot as plt
 warnings.filterwarnings("ignore")
 
 from .utils import fuzzy_search 
@@ -11,7 +9,7 @@ from .metadata import evaluator_name, distribution_oracles
 
 try:
 	from sklearn.metrics import roc_auc_score, f1_score, average_precision_score, precision_score, recall_score, accuracy_score, precision_recall_curve
-	from sklearn.metrics import mean_squared_error, mean_absolute_error, r2_score, cohen_kappa_score
+	from sklearn.metrics import mean_squared_error, mean_absolute_error, r2_score, cohen_kappa_score, auc, roc_curve
 except:
 	ImportError("Please install sklearn by 'conda install -c anaconda scikit-learn' or 'pip install scikit-learn '! ")
 

--- a/tdc/evaluator.py
+++ b/tdc/evaluator.py
@@ -2,6 +2,8 @@ import pandas as pd
 import numpy as np
 import os, sys, json 
 import warnings
+from sklearn.metrics import auc, roc_curve
+import matplotlib.pyplot as plt
 warnings.filterwarnings("ignore")
 
 from .utils import fuzzy_search 
@@ -38,6 +40,82 @@ def precision_at_recall_k(y_true, y_pred, threshold = 0.9):
 
 def pcc(y_true, y_pred):
 	return np.corrcoef(y_true, y_pred)[1,0]
+
+def range_logAUC(true_y, predicted_score, FPR_range=(0.001, 0.1)):
+    """
+    Author: Yunchao "Lance" Liu (lanceknight26@gmail.com)
+    Calculate logAUC in a certain FPR range (default range: [0.001, 0.1]).
+    This was used by previous methods [1] and the reason is that only a
+    small percentage of samples can be selected for experimental tests in
+    consideration of cost. This means only molecules with very high
+    predicted activity values can be worth testing, i.e., the decision
+    threshold is high. And the high decision threshold corresponds to the
+    left side of the ROC curve, i.e., those FPRs with small values. Also,
+    because the threshold cannot be predetermined, the area under the curve
+    is used to consolidate all possible thresholds within a certain FPR
+    range. Finally, the logarithm is used to bias smaller FPRs. The higher
+    the logAUC[0.001, 0.1], the better the performance.
+
+    A perfect classifer gets a logAUC[0.001, 0.1] ) of 1, while a random
+    classifer gets a logAUC[0.001, 0.1] ) of around 0.0215 (See [2])
+
+    References:
+    [1] Mysinger, M.M. and B.K. Shoichet, Rapid Context-Dependent Ligand
+    Desolvation in Molecular Docking. Journal of Chemical Information and
+    Modeling, 2010. 50(9): p. 1561-1573.
+    [2] Mendenhall, J. and J. Meiler, Improving quantitative
+    structure–activity relationship models using Artificial Neural Networks
+    trained with dropout. Journal of computer-aided molecular design,
+    2016. 30(2): p. 177-189.
+    :param true_y: numpy array of the ground truth. Values are either 0 (
+    inactive) or 1(active).
+    :param predicted_score: numpy array of the predicted score (The
+    score does not have to be between 0 and 1)
+    :param FPR_range: the range for calculating the logAUC formated in
+    (x, y) with x being the lower bound and y being the upper bound
+    :return: a numpy array of logAUC of size [1,1]
+    """
+
+    # FPR range validity check
+    if FPR_range == None:
+        raise Exception('FPR range cannot be None')
+    lower_bound = np.log10(FPR_range[0])
+    upper_bound = np.log10(FPR_range[1])
+    if (lower_bound >= upper_bound):
+        raise Exception('FPR upper_bound must be greater than lower_bound')
+
+    # Get the data points' coordinates. log_fpr is the x coordinate, tpr is
+    # the y coordinate.
+    fpr, tpr, thresholds = roc_curve(true_y, predicted_score, pos_label=1)
+    log_fpr = np.log10(fpr)
+
+    # Intecept the curve at the two ends of the region, i.e., lower_bound,
+    # and upper_bound
+    tpr = np.append(tpr, np.interp([lower_bound, upper_bound], log_fpr, tpr))
+    log_fpr = np.append(log_fpr, [lower_bound, upper_bound])
+
+    # Sort both x-, y-coordinates array
+    x = np.sort(log_fpr)
+    y = np.sort(tpr)
+
+    # For visulization of the plot before trimming, uncomment the following
+    # line, with proper libray imported
+    # plt.plot(x, y)
+    # For visulization of the plot in the trimmed area, uncomment the
+    # following line
+    # plt.xlim(lower_bound, upper_bound)
+
+    # Get the index of the lower and upper bounds
+    lower_bound_idx = np.where(x == lower_bound)[-1][-1]
+    upper_bound_idx = np.where(x == upper_bound)[-1][-1]
+
+    # Create a new array trimmed at the lower and upper bound
+    trim_x = x[lower_bound_idx:upper_bound_idx + 1]
+    trim_y = y[lower_bound_idx:upper_bound_idx + 1]
+
+    area = auc(trim_x, trim_y) / 2
+
+    return area
 
 class Evaluator:
 
@@ -114,6 +192,8 @@ class Evaluator:
 		elif self.name == 'fcd_distance':
 			from .chem_utils import fcd_distance
 			self.evaluator_func = fcd_distance
+		elif self.name == 'range_logAUC':
+			self.evaluator_func == range_logAUC()
 
 	def __call__(self, *args, **kwargs):
 		"""call the evaluator function on targets and predictions

--- a/tdc/metadata.py
+++ b/tdc/metadata.py
@@ -176,7 +176,7 @@ property_names = ['drd2', 'qed', 'logp', 'sa', 'gsk3b', 'jnk3',]
 
 evaluator_name = ['roc-auc', 'f1', 'pr-auc', 'precision', 'recall', \
 				  'accuracy', 'mse', 'rmse', 'mae', 'r2', 'micro-f1', 'macro-f1', \
-				  'kappa', 'avg-roc-auc', 'rp@k', 'pr@k', 'pcc', 'spearman']
+				  'kappa', 'avg-roc-auc', 'rp@k', 'pr@k', 'pcc', 'spearman', 'range_logAUC']
 
 evaluator_name.extend(distribution_oracles)
 


### PR DESCRIPTION
Author: Yunchao "Lance" Liu (lanceknight26@gmail.com)
Calculate logAUC in a certain FPR range (default range: [0.001, 0.1]).
This was used by previous methods [1] and the reason is that only a
small percentage of samples can be selected for experimental tests in
consideration of cost. This means only molecules with very high
predicted activity values can be worth testing, i.e., the decision
threshold is high. And the high decision threshold corresponds to the
left side of the ROC curve, i.e., those FPRs with small values. Also,
because the threshold cannot be predetermined, the area under the curve
is used to consolidate all possible thresholds within a certain FPR
range. Finally, the logarithm is used to bias smaller FPRs. The higher
the logAUC[0.001, 0.1], the better the performance.

A perfect classifer gets a logAUC[0.001, 0.1] ) of 1, while a random
classifer gets a logAUC[0.001, 0.1] ) of around 0.0215 (See [2])

References:
[1] Mysinger, M.M. and B.K. Shoichet, Rapid Context-Dependent Ligand
Desolvation in Molecular Docking. Journal of Chemical Information and
Modeling, 2010. 50(9): p. 1561-1573.
[2] Mendenhall, J. and J. Meiler, Improving quantitative
structure–activity relationship models using Artificial Neural Networks
trained with dropout. Journal of computer-aided molecular design,
2016. 30(2): p. 177-189.
:param true_y: numpy array of the ground truth. Values are either 0 (
inactive) or 1(active).
:param predicted_score: numpy array of the predicted score (The
score does not have to be between 0 and 1)
:param FPR_range: the range for calculating the logAUC formated in
(x, y) with x being the lower bound and y being the upper bound
:return: a numpy array of logAUC of size [1,1]
 