### PR TITLE
fix: dynamic oracle loading (sklearn version)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,21 +18,21 @@
 
 [**Website**](https://tdcommons.ai) | [**NeurIPS 2021 Paper**](https://openreview.net/pdf?id=8nvgnORnoWr) | [**Long Paper**](https://arxiv.org/abs/2102.09548) | [**Slack**](https://join.slack.com/t/pytdc/shared_invite/zt-x0ujg5v6-zwtQZt83fhRdgrYjXRFz5g) | [**TDC Mailing List**](https://groups.io/g/tdc) | [**TDC Documentation**](https://tdc.readthedocs.io/) | [**Contribution Guidelines**](CONTRIBUTE.md)
 
-Artificial intelligence holds promise in enabling breakthroughs and discoveries in therapeutic science. **Therapeutics Data Commons** is a coordinated initiative to access and evaluate artificial intelligence capability across therapeutic modalities and stages of discovery, supporting the development of AI methods, with a strong bent towards establishing the foundation of which AI methods are most suitable for drug discovery applications and why.
+Artificial intelligence is poised to reshape therapeutic science. **Therapeutics Data Commons** is a coordinated initiative to access and evaluate artificial intelligence capability across therapeutic modalities and stages of discovery, supporting the development of AI methods, with a strong bent towards establishing the foundation of which AI methods are most suitable for drug discovery applications and why.
 
 Researchers across disciplines can use TDC for numerous applications. AI-solvable tasks, AI-ready datasets, and curated benchmarks in TDC serve as a meeting point between biochemical and AI scientists. TDC facilitates algorithmic and scientific advances and accelerate machine learning method development, validation and transition into biomedical and clinical implementation.
 
-TDC is an open-science initiative. We welcome [contributions from the community.](CONTRIBUTE.md)!
+TDC is an open-science initiative. We welcome [contributions from the community.](CONTRIBUTE.md)
 
 ## Key TDC Presentations and Publications
 
-[1] Huang, Fu, Gao, et al., Therapeutics Data Commons: Machine Learning Datasets and Tasks for Drug Discovery and Development, NeurIPS 2021 [**\[Paper\]**](https://openreview.net/forum?id=8nvgnORnoWr)** [**\[Poster\]**](https://drive.google.com/file/d/1LfF8mfPLUqAVEzH3KPBxDO_VF7nLFtiJ/view?usp=sharing) 
+[1] Huang, Fu, Gao, et al., Therapeutics Data Commons: Machine Learning Datasets and Tasks for Drug Discovery and Development, NeurIPS 2021 [**\[Paper\]**](https://openreview.net/forum?id=8nvgnORnoWr) [**\[Poster\]**](https://drive.google.com/file/d/1LfF8mfPLUqAVEzH3KPBxDO_VF7nLFtiJ/view?usp=sharing) 
 
-[2] Huang et al., Benchmarking Molecular Machine Learning in Therapeutics Data Commons, ELLIS ML4Molecules 2021 [**\[Paper\]**](https://cloud.ml.jku.at/s/54pB5Eqf6ftX7qA)** [**\[Slides\]**](https://drive.google.com/file/d/1iOSW_5eruca4vdygDxS1H64c49oQuH40/view?usp=sharing) 
+[2] Huang et al., Benchmarking Molecular Machine Learning in Therapeutics Data Commons, ELLIS ML4Molecules 2021 [**\[Paper\]**](https://cloud.ml.jku.at/s/54pB5Eqf6ftX7qA) [**\[Slides\]**](https://drive.google.com/file/d/1iOSW_5eruca4vdygDxS1H64c49oQuH40/view?usp=sharing) 
 
 [3] Huang et al., Therapeutics Data Commons: Machine Learning Datasets and Tasks for Drug Discovery and Development, Baylearn 2021 [**\[Slides\]**](https://drive.google.com/file/d/1BNpk3dOdqE3ksgyVV-V3xySdBMq-8cXL/view?usp=sharing) [**\[Poster\]**](https://drive.google.com/file/d/1LfF8mfPLUqAVEzH3KPBxDO_VF7nLFtiJ/view?usp=sharing)
 
-[4] Huang, Fu, Gao et al., Therapeutics Data Commons, NSF-Harvard Symposium on Drugs for Future Pandemics 2020 [**\[#futuretx20\]**](https://www.drugsymposium.org/)** [**\[Slides\]**](https://drive.google.com/file/d/11eTrh_lsqPcwu3RZRYjJGNpJ3s18YlBS/view) [**\[Video\]**](https://youtu.be/ZuCOhEZtaOw)
+[4] Huang, Fu, Gao et al., Therapeutics Data Commons, NSF-Harvard Symposium on Drugs for Future Pandemics 2020 [**\[#futuretx20\]**](https://www.drugsymposium.org/) [**\[Slides\]**](https://drive.google.com/file/d/11eTrh_lsqPcwu3RZRYjJGNpJ3s18YlBS/view) [**\[Video\]**](https://youtu.be/ZuCOhEZtaOw)
 
 [5] [TDC User Group Meetup, Jan 2022](https://harvard.zoom.us/rec/share/HO0TjRPs56YG-Fu3i033izaTwebB4KwUhPeNURkWSI-anrH9su03lCtUlHeZG-WP.67ZJmAIHsD7Q_2GQ) [**\[Agenda\]**](https://shoutout.wix.com/so/d1Nv1pC2d#/main)
 

--- a/tdc/chem_utils/oracle/oracle.py
+++ b/tdc/chem_utils/oracle/oracle.py
@@ -9,8 +9,6 @@ from abc import abstractmethod
 from functools import partial
 from typing import List
 import time, os, math, re
-from packaging import version
-import pkg_resources
 
 try: 
   import rdkit
@@ -41,8 +39,6 @@ mean2func = {
   'geometric': gmean, 
   'arithmetic': np.mean, 
 }
-SCIKIT_LEARN_VERSION = version.parse(pkg_resources.get_distribution("scikit-learn").version)
-
 
 def smiles_to_rdkit_mol(smiles):
   """Convert smiles into rdkit's mol (molecule) format. 
@@ -404,10 +400,10 @@ def calculateScore(m):
 
 """Scores based on an ECFP classifier for activity."""
 
-def dynamic_sklearn_model_loader(name: str):
+def load_pickled_model(name: str):
   """
-  Loading a model trained with SKLearn dynamically dependent on the version.
-  Necessary due to changes in package structure in sklearn 0.24.
+  Loading a pretrained model serialized with pickle.
+  Usually for sklearn models.
 
   Args:
     name: Name of the model to load.
@@ -416,8 +412,6 @@ def dynamic_sklearn_model_loader(name: str):
     The model.
   """
 
-  if SCIKIT_LEARN_VERSION >= version.parse("0.24.0"):
-    name = name.replace('.pkl', '_sklearn>024.pkl')
   try:
     with open(name, "rb") as f:
       model = pickle.load(f)
@@ -429,7 +423,7 @@ def dynamic_sklearn_model_loader(name: str):
 # clf_model = None
 def load_drd2_model():
     name = 'oracle/drd2.pkl'
-    return dynamic_sklearn_model_loader(name)
+    return load_pickled_model(name)
 
 def fingerprints_from_mol(mol):
     fp = AllChem.GetMorganFingerprint(mol, 3, useCounts=True, useFeatures=True)
@@ -465,7 +459,7 @@ def drd2(smile):
 
 def load_cyp3a4_veith():
   oracle_file = "oracle/cyp3a4_veith.pkl"
-  return dynamic_sklearn_model_loader(oracle_file)
+  return load_pickled_model(oracle_file)
 
 def cyp3a4_veith(smiles):
   try:
@@ -595,7 +589,7 @@ def SA(s):
 
 def load_gsk3b_model():
     gsk3_model_path = 'oracle/gsk3b.pkl'
-    return dynamic_sklearn_model_loader(gsk3_model_path)
+    return load_pickled_model(gsk3_model_path)
 
 def gsk3b(smiles):
     """Evaluate GSK3B score of a SMILES string
@@ -631,7 +625,7 @@ class jnk3:
   """  
   def __init__(self):
     jnk3_model_path = 'oracle/jnk3.pkl'
-    self.jnk3_model = dynamic_sklearn_model_loader(jnk3_model_path)
+    self.jnk3_model = load_pickled_model(jnk3_model_path)
 
   def __call__(self, smiles):
     molecule = smiles_to_rdkit_mol(smiles)

--- a/tdc/metadata.py
+++ b/tdc/metadata.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 # Author: TDC Team
 # License: MIT
-
+from packaging import version
+import pkg_resources
 
 """This file contains all metadata of datasets in TDC.
 
@@ -622,6 +623,13 @@ oracle2id = {'drd2': 4178625,
 			 'fpscores': 4170416, 
 			 'cyp3a4_veith': 4411249, 
 			}
+# Newer scikit-learn versions have an updated model restoring logic and thus require
+# a different source file.
+scikit_learn_version = version.parse(pkg_resources.get_distribution("scikit-learn").version)
+if scikit_learn_version >= version.parse("0.24.0"):
+	oracle2id['drd2'] = 6405398
+	oracle2id['jnk3'] = 6405399
+	oracle2id['gsk3b'] = 6405400
 
 benchmark2type = {'admet_group': 'zip',
                   'drugcombo_group': 'zip',


### PR DESCRIPTION
Addresses #163 

This is a draft PR with a rough sketch. Let's discuss here :) 

- Draft PR for dynamic loading of oracles dependent on `sklearn` version.
- Idea: Determine the sklearn version at runtime. Then, load the correct version of the oracle, i.e., the one that was trained with the sklearn version that the current user has. Disadvantage: Users with different sklearn version will see slightly different predictions for the same Oracle-smiles pair.
- The idea would be to just append a `_sklearn>024` to the filename of the original model on your COS
- This should be minimally invasive as it is perfectly backwards compatible and does not have side effects


TODO:
- [ ] I do not know the codebase well enough to see whether this sklearn versioning problem might arise in other places of the package as well.
