### PR TITLE
Add pampa_ncats dataset

### DIFF
--- a/tdc/metadata.py
+++ b/tdc/metadata.py
@@ -53,7 +53,7 @@ Attributes:
     name2type (dict): mapping from dataset names to downloaded file format
     oracle2id (dict): mapping from oracle names to dataverse id
     oracle2type (dict): mapping from oracle names to downloaded file format
-    receptor2id (dict): mapping from receptor id to dataverse id 
+    receptor2id (dict): mapping from receptor id to dataverse id
     oracle_names (list): list of all oracle names
     paired_dataset_names (list): all paired dataset names
     paratope_dataset_names (list): all paratope dataset names
@@ -85,6 +85,7 @@ adme_dataset_names = ['lipophilicity_astrazeneca',
  'solubility_aqsoldb',
  'hydrationfreeenergy_freesolv',
  'caco2_wang',
+ 'pampa_ncats'
  'hia_hou',
  'pgp_broccatelli',
  'bioavailability_ma',
@@ -94,17 +95,17 @@ adme_dataset_names = ['lipophilicity_astrazeneca',
  'cyp3a4_veith',
  'cyp1a2_veith',
  'cyp2c9_veith',
- 'cyp2c9_substrate_carbonmangels', 
+ 'cyp2c9_substrate_carbonmangels',
  'cyp2d6_substrate_carbonmangels',
- 'cyp3a4_substrate_carbonmangels', 
+ 'cyp3a4_substrate_carbonmangels',
  'bbb_martins',
  'ppbr_az',
  'half_life_obach',
  'clearance_hepatocyte_az',
  'clearance_microsome_az']
 
-hts_dataset_names = ['hiv', 
-'sarscov2_3clpro_diamond', 
+hts_dataset_names = ['hiv',
+'sarscov2_3clpro_diamond',
 'sarscov2_vitro_touret']
 
 qm_dataset_names = ['qm7', 'qm7b', 'qm8', 'qm9']
@@ -174,7 +175,7 @@ biokg_library_names = ['hetionet']
 # oracles
 
 #### evaluator for distribution learning, the input of __call__ is list of smiles
-distribution_oracles = ['novelty', 'diversity', 'uniqueness', 'validity', 'fcd_distance', 'kl_divergence']  
+distribution_oracles = ['novelty', 'diversity', 'uniqueness', 'validity', 'fcd_distance', 'kl_divergence']
 
 docking_oracles = ['rmsd', 'kabsch_rmsd', 'smina']
 
@@ -201,9 +202,9 @@ guacamol_oracle = ['rediscovery', 'similarity', 'median', 'isomers', 'mpo', 'hop
 ####################################
 # Benchmark Datasets
 
-admet_benchmark = {'ADME': ['caco2_wang', 
+admet_benchmark = {'ADME': ['caco2_wang',
 							'hia_hou',
-							'pgp_broccatelli', 
+							'pgp_broccatelli',
 							'bioavailability_ma',
 							'lipophilicity_astrazeneca',
 							'solubility_aqsoldb',
@@ -232,11 +233,11 @@ drugsyn_benchmark = {'Synergy': ['drugcomb_css',
                                  'drugcomb_zip'
                                  ]}
 
-dti_dg_benchmark = {'DTI': ['bindingdb_patent']} 
+dti_dg_benchmark = {'DTI': ['bindingdb_patent']}
 
 docking_benchmark = {'Targets': ['1iep', '2rgp', '3eml', '3ny8', '4rlu', '4unn', '5mo4', '7l11', '3pbl',]}
 
-docking_target_info = {'3pbl': {'center': (9, 22.5, 26), 'size': (15, 15, 15)}, 
+docking_target_info = {'3pbl': {'center': (9, 22.5, 26), 'size': (15, 15, 15)},
 					   '1iep': {'center': (15.61389189189189, 53.38013513513513, 15.454837837837842), 'size': (15, 15, 15)},
 					   '2rgp': {'center': (16.292121212121213, 34.87081818181819, 92.0353030303030), 'size': (15, 15, 15)},
 					   '3eml': {'center': (-9.063639999999998, -7.1446, 55.86259999999999), 'size': (15, 15, 15)},
@@ -252,7 +253,7 @@ docking_target_info = {'3pbl': {'center': (9, 22.5, 26), 'size': (15, 15, 15)},
 #### Benchmark Metrics
 admet_metrics = {'caco2_wang': 'mae',
 				'hia_hou': 'roc-auc',
-				'pgp_broccatelli': 'roc-auc', 
+				'pgp_broccatelli': 'roc-auc',
 				'bioavailability_ma': 'roc-auc',
 				'lipophilicity_astrazeneca': 'mae',
 				'solubility_aqsoldb': 'mae',
@@ -295,7 +296,7 @@ dti_dg_metrics = {'bindingdb_patent': 'pcc'}
 #### Benchmark Splits
 admet_splits = {'caco2_wang': 'scaffold',
 				'hia_hou': 'scaffold',
-				'pgp_broccatelli': 'scaffold', 
+				'pgp_broccatelli': 'scaffold',
 				'bioavailability_ma': 'scaffold',
 				'lipophilicity_astrazeneca': 'scaffold',
 				'solubility_aqsoldb': 'scaffold',
@@ -346,7 +347,7 @@ download_receptor_oracle_name = ['1iep_docking', '2rgp_docking', '3eml_docking',
 
 meta_oracle_name = ['isomer_meta', 'rediscovery_meta', 'similarity_meta', 'median_meta', 'docking_score', 'molecule_one_synthesis', 'pyscreener']
 
-oracle_names = download_oracle_names + trivial_oracle_names + distribution_oracles + synthetic_oracle_name + meta_oracle_name + docking_oracles + download_receptor_oracle_name 
+oracle_names = download_oracle_names + trivial_oracle_names + distribution_oracles + synthetic_oracle_name + meta_oracle_name + docking_oracles + download_receptor_oracle_name
 
 molgenpaired_dataset_names = ['qed', 'drd2', 'logp']
 
@@ -388,13 +389,13 @@ def get_task2category():
 	return task2category
 
 dataset_names = {"Tox": toxicity_dataset_names,
-				"ADME": adme_dataset_names, 
-				"HTS": hts_dataset_names, 
-				"DTI": dti_dataset_names, 
-				"PPI": ppi_dataset_names, 
+				"ADME": adme_dataset_names,
+				"HTS": hts_dataset_names,
+				"DTI": dti_dataset_names,
+				"PPI": ppi_dataset_names,
 				"DDI": ddi_dataset_names,
 				"RetroSyn": retrosyn_dataset_names,
-				"Reaction": forwardsyn_dataset_names, 
+				"Reaction": forwardsyn_dataset_names,
 				"MolGen": single_molecule_dataset_names,
 				"sbdd": multiple_molecule_dataset_names,
 				"PeptideMHC": peptidemhc_dataset_names,
@@ -406,9 +407,9 @@ dataset_names = {"Tox": toxicity_dataset_names,
 				"DrugSyn": drugsyn_dataset_names,
 				"MTI": mti_dataset_names,
 				"GDA": gda_dataset_names,
-				"Paratope": paratope_dataset_names, 
-				"Yields": yield_dataset_names, 
-				"Catalyst": catalyst_dataset_names, 
+				"Paratope": paratope_dataset_names,
+				"Yields": yield_dataset_names,
+				"Catalyst": catalyst_dataset_names,
 				"CRISPROutcome": crisproutcome_dataset_names,
 				"test_single_pred": test_single_pred_dataset_names,
 				"test_multi_pred": test_multi_pred_dataset_names,
@@ -439,6 +440,7 @@ name2type = {'toxcast': 'tab',
  'solubility_aqsoldb': 'tab',
  'hydrationfreeenergy_freesolv': 'tab',
  'caco2_wang': 'tab',
+ 'pampa_ncats': 'tab',
  'hia_hou': 'tab',
  'pgp_broccatelli': 'tab',
  'f20_edrug3d': 'tab',
@@ -450,10 +452,10 @@ name2type = {'toxcast': 'tab',
  'cyp3a4_veith': 'tab',
  'cyp1a2_veith': 'tab',
  'cyp2c9_veith': 'tab',
- 'cyp2c9_substrate_carbonmangels': 'tab', 
+ 'cyp2c9_substrate_carbonmangels': 'tab',
  'cyp2d6_substrate_carbonmangels': 'tab',
- 'cyp3a4_substrate_carbonmangels': 'tab', 
- 'carcinogens_lagunin': 'tab', 
+ 'cyp3a4_substrate_carbonmangels': 'tab',
+ 'carcinogens_lagunin': 'tab',
  'halflife_edrug3d': 'tab',
  'clearance_edrug3d': 'tab',
  'bbb_adenot': 'tab',
@@ -476,12 +478,12 @@ name2type = {'toxcast': 'tab',
  'mhc2_iedb_jensen': 'tab',
  'uspto': 'csv',
  'uspto50k': 'tab',
- 'zinc': 'tab', 
+ 'zinc': 'tab',
  'moses': 'tab',
  'chembl': 'tab',
  'chembl_v29': 'csv',
- 'qed': 'tab', 
- 'drd2': 'tab', 
+ 'qed': 'tab',
+ 'drd2': 'tab',
  'logp': 'tab',
  'drugcomb':'pkl',
  'gdsc1': 'pkl',
@@ -502,17 +504,17 @@ name2type = {'toxcast': 'tab',
  'mirtarbase': 'csv',
  'disgenet': 'csv',
  'sabdab_liberis': 'pkl',
- 'uspto_yields': 'pkl', 
+ 'uspto_yields': 'pkl',
  'uspto_catalyst': 'csv',
  'buchwald-hartwig': 'pkl',
- 'hetionet':'tab', 
+ 'hetionet':'tab',
  'herg': 'tab',
  'herg_central': 'tab',
  'dili': 'tab',
  'ppbr_az': 'tab',
  'ames': 'tab',
  'skin_reaction': 'tab',
- 'drugbank_drugs': 'csv', 
+ 'drugbank_drugs': 'csv',
  'clearance_microsome_az': 'tab',
  'clearance_hepatocyte_az': 'tab',
  'half_life_obach': 'tab',
@@ -535,6 +537,7 @@ name2id = {'bbb_adenot': 4259565,
  'bindingdb_patent': 4724851,
  'bioavailability_ma': 4259567,
  'caco2_wang': 4259569,
+ 'pampa_ncats': 6545689,
  'clearance_edrug3d': 4259571,
  'clintox': 4259572,
  'cyp1a2_veith': 4259573,
@@ -544,7 +547,7 @@ name2id = {'bbb_adenot': 4259565,
  'cyp3a4_veith': 4259582,
  'cyp2c9_substrate_carbonmangels': 4259584,
  'cyp2d6_substrate_carbonmangels': 4259578,
- 'cyp3a4_substrate_carbonmangels': 4259581, 
+ 'cyp3a4_substrate_carbonmangels': 4259581,
  'carcinogens_lagunin': 4259570,
  'davis': 5219748,
  'drugbank': 4139573,
@@ -574,16 +577,16 @@ name2id = {'bbb_adenot': 4259565,
  'moses': 4170962,
  'chembl': 4170965,
  'chembl_v29': 5767979,
- 'qed': 4170959, 
- 'drd2': 4170957, 
- 'logp': 4170961, 
+ 'qed': 4170959,
+ 'drd2': 4170957,
+ 'logp': 4170961,
  'gdsc1': 4165726,
  'gdsc2': 4165727,
- 'iedb_jespersen': 4165725, 
+ 'iedb_jespersen': 4165725,
  'pdb_jespersen': 4165724,
- 'qm7': 6358510, 
- 'qm7b': 6358512, 
- 'qm8': 6358513,  
+ 'qm7': 6358510,
+ 'qm7b': 6358512,
+ 'qm8': 6358513,
  'qm9': 6179310, ### 4167112, 6175612
 #  'scpdb': None,
 #  'dude': None,
@@ -597,9 +600,9 @@ name2id = {'bbb_adenot': 4259565,
  'sabdab_liberis': 4168425,
  'uspto50k': 4171823,
  'buchwald-hartwig': 6175640,
- 'uspto_yields': 4186956, 
+ 'uspto_yields': 4186956,
  'uspto_catalyst': 4171574,
- 'uspto': 4171642, 
+ 'uspto': 4171642,
  'hetionet': 4201734,
  'herg': 4259588,
  'herg_central': 5740618,
@@ -621,27 +624,27 @@ name2id = {'bbb_adenot': 4259565,
  'primekg_drug_feature': 6180619,
  'primekg_disease_feature': 6180618}
 
-oracle2type = {'drd2': 'pkl', 
-			   'jnk3': 'pkl', 
+oracle2type = {'drd2': 'pkl',
+			   'jnk3': 'pkl',
 			   'gsk3b': 'pkl',
-			   'fpscores': 'pkl', 
-			   'cyp3a4_veith': 'pkl', 
-			   'smina': 'static', 
-			   'drd2_current': 'pkl', 
-			   'jnk3_current': 'pkl', 
-			   'gsk3b_current': 'pkl', 			   
+			   'fpscores': 'pkl',
+			   'cyp3a4_veith': 'pkl',
+			   'smina': 'static',
+			   'drd2_current': 'pkl',
+			   'jnk3_current': 'pkl',
+			   'gsk3b_current': 'pkl',
 			   }
 
 oracle2id = {'drd2': 4178625,
 			 'gsk3b': 4170295,
 			 'jnk3': 4170293,
-			 'fpscores': 4170416, 
+			 'fpscores': 4170416,
 			 'cyp3a4_veith': 4411249,
-			 'smina': 6361665, 
-			 'cyp3a4_veith': 4411249, 
-			 'drd2_current': 6413411, 
-			 'jnk3_current': 6413420, 
-			 'gsk3b_current': 6413412,			 
+			 'smina': 6361665,
+			 'cyp3a4_veith': 4411249,
+			 'drd2_current': 6413411,
+			 'jnk3_current': 6413420,
+			 'gsk3b_current': 6413412,
 			}
 
 
@@ -655,15 +658,15 @@ benchmark2id = {'admet_group': 4426004,
                 'docking_group': 4554082,
                 'dti_dg_group': 4742443}
 
-receptor2id = { 
-			   '1iep': [5137914, 5617659], 
-			   '2rgp': [5137916, 5617662], 
-			   '3eml': [5137919, 5617663], 
-			   '3ny8': [5137915, 5617665], 
-			   '4rlu': [5137918, 5617658], 
-			   '4unn': [5137917, 5617661], 
-			   '5mo4': [5137920, 5617664], 
-			   '7l11': [5137921, 5617660], 
+receptor2id = {
+			   '1iep': [5137914, 5617659],
+			   '2rgp': [5137916, 5617662],
+			   '3eml': [5137919, 5617663],
+			   '3ny8': [5137915, 5617665],
+			   '4rlu': [5137918, 5617658],
+			   '4unn': [5137917, 5617661],
+			   '5mo4': [5137920, 5617664],
+			   '7l11': [5137921, 5617660],
 			   '3pbl': [5257195, 5617666], } ## 'drd3': 5137901,
 
 
@@ -745,5 +748,3 @@ name2idlist = {
 	'dude': [6429245, 6429251],
 	'scpdb': [6431629, 6431631],
 }
-
-


### PR DESCRIPTION
Pull request for #172

[Script for data download and basic preprocessing](https://gist.github.com/iwwwish/86b2d832405d8cd3a70fece5badad903)

### PAMPA Permeability

**Dataset Description**: PAMPA (parallel artificial membrane permeability assay) is a commonly employed assay to evaluate drug permeability across the cellular membrane. PAMPA is a non-cell-based, low-cost and high-throughput alternative to cellular models. Although PAMPA does not model active and efflux transporters, it still provides permeability values that are useful for absorption prediction because the majority of drugs are absorbed by passive diffusion through the membrane.

**Task Description**: Binary classification. Given a compound's SMILES string, predict whether it is has high permeability (1) or low-to-moderate permeability (0) in PAMPA assay.

**Dataset Statistics**: NCATS set - 2035 compounds; Approved drugs set - 142 drugs.

**Dataset Split**: `Random Split` `Scaffold Split`

```python
from tdc.single_pred import ADME
data = ADME(name = 'pampa_ncats') # validation_set = False by default
data, validation_set = ADME(name = 'pampa_ncats', validation_set = True)
split = data.get_split()
```

**Reference**: Siramshetty, V.B., Shah, P., et al. "Validating ADME QSAR Models Using Marketed Drugs." SLAS Discovery 2021 Dec;26(10):1326-1336. doi: 10.1177/24725552211017520.

**Dataset License**: Not Specified. CC BY 4.0.

**Updated Dataverse Metadata IDs**: NCATS set - [6576972](https://dataverse.harvard.edu/api/access/datafile/6576972); Approved drugs set - [6576980](https://dataverse.harvard.edu/api/access/datafile/6576980)