### PR TITLE
RDKit is directly available from PyPI, don't need `rdkit-pypi`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-rdkit-pypi
+rdkit
 fuzzywuzzy
 numpy
 pandas


### PR DESCRIPTION
rdkit is now listed on pypi normally - don't need this community contributed version anymore (see the Note on the rdkit-pypi page: https://pypi.org/project/rdkit-pypi/)