### PR TITLE
fix cellxgene file to not include duplicate disabler as that's encoded in conda package now

### DIFF
--- a/tdc/resource/cellxgene_census.py
+++ b/tdc/resource/cellxgene_census.py
@@ -1,8 +1,3 @@
-# TODO: tmp fix
-import os
-
-os.environ['KMP_DUPLICATE_LIB_OK'] = "TRUE"
-# TODO: remove
 import cellxgene_census
 import gget
 import tiledbsoma


### PR DESCRIPTION
fix cellxgene file to not include duplicate disabler as that's encoded in conda package now