### PR TITLE
add gene perturb outcome tasks

### DIFF
--- a/tdc/dataset_configs/config_map.py
+++ b/tdc/dataset_configs/config_map.py
@@ -1,5 +1,5 @@
 from .pentelute_mdm2_ace2_12ca5_config import PenteluteProteinPeptideConfig
-from .scperturb_config import SCPerturb
+from .scperturb_config import SCPerturb, SCPerturb_Gene
 
 scperturb_datasets = [
     "scperturb_drug_AissaBenevolenskaya2021",
@@ -9,6 +9,11 @@ scperturb_datasets = [
     "scperturb_drug_ZhaoSims2021",
 ]
 
+scperturb_gene_datasets = [
+    "scperturb_gene_NormanWeissman2019",
+    "scperturb_gene_ReplogleWeissman2022_rpe1",
+    "scperturb_gene_ReplogleWeissman2022_k562_essential",
+]
 
 class ConfigMap(dict):
     """
@@ -19,3 +24,5 @@ class ConfigMap(dict):
         self["pentelute_mdm2_ace2_12ca5"] = PenteluteProteinPeptideConfig
         for ds in scperturb_datasets:
             self[ds] = SCPerturb
+        for ds in scperturb_gene_datasets:
+            self[ds] = SCPerturb_Gene

--- a/tdc/dataset_configs/config_map.py
+++ b/tdc/dataset_configs/config_map.py
@@ -15,6 +15,7 @@ scperturb_gene_datasets = [
     "scperturb_gene_ReplogleWeissman2022_k562_essential",
 ]
 
+
 class ConfigMap(dict):
     """
     The ConfigMap stores key-value pairs where the key is a dataset string name and the value is a config class.

--- a/tdc/dataset_configs/scperturb_config.py
+++ b/tdc/dataset_configs/scperturb_config.py
@@ -31,9 +31,10 @@ class SCPerturb_Gene(DatasetConfig):
             args_for_functions=[
                 {
                     "obs_cols": [
-                        'UMI_count', 'cancer', 'cell_line', 'disease', 'guide_id',
-                           'ncounts', 'ngenes', 'nperts', 'organism', 'percent_mito',
-                           'percent_ribo', 'perturbation', 'perturbation_type', 'tissue_type'
+                        'UMI_count', 'cancer', 'cell_line', 'disease',
+                        'guide_id', 'ncounts', 'ngenes', 'nperts', 'organism',
+                        'percent_mito', 'percent_ribo', 'perturbation',
+                        'perturbation_type', 'tissue_type'
                     ],
                 },
             ],

--- a/tdc/dataset_configs/scperturb_config.py
+++ b/tdc/dataset_configs/scperturb_config.py
@@ -19,3 +19,22 @@ class SCPerturb(DatasetConfig):
                 },
             ],
         )
+
+
+class SCPerturb_Gene(DatasetConfig):
+    """Configuration for the scPerturb genetic perturbation datasets"""
+
+    def __init__(self):
+        super(SCPerturb_Gene, self).__init__(
+            data_processing_class=AnnDataToDataFrame,
+            functions_to_run=["anndata_to_df"],
+            args_for_functions=[
+                {
+                    "obs_cols": [
+                        'UMI_count', 'cancer', 'cell_line', 'disease', 'guide_id',
+                           'ncounts', 'ngenes', 'nperts', 'organism', 'percent_mito',
+                           'percent_ribo', 'perturbation', 'perturbation_type', 'tissue_type'
+                    ],
+                },
+            ],
+        )

--- a/tdc/feature_generators/anndata_to_dataframe.py
+++ b/tdc/feature_generators/anndata_to_dataframe.py
@@ -16,10 +16,9 @@ class AnnDataToDataFrame(DataFeatureGenerator):
         adata = dataset
         if not isinstance(adata.X, np.ndarray):
             adata.X = adata.X.todense()
-        df_main = pd.DataFrame(
-            adata.X if adata.X is not None else adata.X,
-            columns=adata.var_names,
-            index=adata.obs_names)
+        df_main = pd.DataFrame(adata.X if adata.X is not None else adata.X,
+                               columns=adata.var_names,
+                               index=adata.obs_names)
         dfobs = pd.DataFrame(adata.obs,
                              columns=adata.obs.keys(),
                              index=adata.obs.index)

--- a/tdc/feature_generators/anndata_to_dataframe.py
+++ b/tdc/feature_generators/anndata_to_dataframe.py
@@ -3,6 +3,7 @@ Class for customizations when transforming anndata format objects to pandas.Data
 """
 
 import pandas as pd
+import numpy as np
 from .data_feature_generator import DataFeatureGenerator
 
 
@@ -13,8 +14,10 @@ class AnnDataToDataFrame(DataFeatureGenerator):
         if dataset is None:
             raise ValueError("dataset must be specified")
         adata = dataset
+        if not isinstance(adata.X, np.ndarray):
+            adata.X = adata.X.todense()
         df_main = pd.DataFrame(
-            adata.X.todense() if adata.X is not None else adata.X,
+            adata.X if adata.X is not None else adata.X,
             columns=adata.var_names,
             index=adata.obs_names)
         dfobs = pd.DataFrame(adata.obs,

--- a/tdc/metadata.py
+++ b/tdc/metadata.py
@@ -187,6 +187,9 @@ cellxgene_dataset_names = [
     "scperturb_drug_SrivatsanTrapnell2020_sciplex3",
     "scperturb_drug_SrivatsanTrapnell2020_sciplex4",
     "scperturb_drug_ZhaoSims2021",
+    "scperturb_gene_NormanWeissman2019",
+    "scperturb_gene_ReplogleWeissman2022_rpe1",
+    "scperturb_gene_ReplogleWeissman2022_k562_essential",
 ]
 
 ####################################
@@ -744,6 +747,9 @@ name2type = {
     "scperturb_drug_SrivatsanTrapnell2020_sciplex3": "h5ad",
     "scperturb_drug_SrivatsanTrapnell2020_sciplex4": "h5ad",
     "scperturb_drug_ZhaoSims2021": "h5ad",
+    "scperturb_gene_NormanWeissman2019": "h5ad",
+    "scperturb_gene_ReplogleWeissman2022_rpe1": "h5ad",
+    "scperturb_gene_ReplogleWeissman2022_k562_essential": "h5ad",
 }
 
 name2id = {
@@ -864,6 +870,9 @@ name2id = {
     "scperturb_drug_SrivatsanTrapnell2020_sciplex3": 9845397,
     "scperturb_drug_SrivatsanTrapnell2020_sciplex4": 9845395,
     "scperturb_drug_ZhaoSims2021": 9845393,
+    "scperturb_gene_NormanWeissman2019": 10133995,
+    "scperturb_gene_ReplogleWeissman2022_rpe1": 10133996,
+    "scperturb_gene_ReplogleWeissman2022_k562_essential": 10134031,
 }
 
 oracle2type = {

--- a/tdc/multi_pred/__init__.py
+++ b/tdc/multi_pred/__init__.py
@@ -12,3 +12,4 @@ from .proteinpeptide import ProteinPeptide
 from .test_multi_pred import TestMultiPred
 from .tcr_epi import TCREpitopeBinding
 from .trialoutcome import TrialOutcome
+from .perturboutcome import PerturbOutcome

--- a/tdc/multi_pred/perturboutcome.py
+++ b/tdc/multi_pred/perturboutcome.py
@@ -24,4 +24,3 @@ class PerturbOutcome(CellXGeneTemplate):
 
     def get_dropout_genes(self):
         raise ValueError("TODO")
-    

--- a/tdc/multi_pred/perturboutcome.py
+++ b/tdc/multi_pred/perturboutcome.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+# Author: TDC Team
+# License: MIT
+
+import warnings
+
+warnings.filterwarnings("ignore")
+import sys
+
+from ..utils import print_sys
+from .cellxgene import CellXGeneTemplate
+
+
+class PerturbOutcome(CellXGeneTemplate):
+
+    def __init__(self, name, path="./data", print_stats=False):
+        super().__init__(name, path, print_stats)
+
+    def get_mean_expression(self):
+        raise ValueError("TODO")
+
+    def get_DE_genes(self):
+        raise ValueError("TODO")
+
+    def get_dropout_genes(self):
+        raise ValueError("TODO")
+    


### PR DESCRIPTION
here is an initial PR for adding scperturb datasets - here are the demo code:

```
from tdc.multi_pred import PerturbOutcome
test_loader = PerturbOutcome(name="scperturb_gene_NormanWeissman2019")
testdf = test_loader.get_data()
```

here are the dataset supported "scperturb_gene_NormanWeissman2019"/  "scperturb_gene_ReplogleWeissman2022_rpe1"/ "scperturb_gene_ReplogleWeissman2022_k562_essential"
 
 this also supports the existing drug perturbation datasets