### PR TITLE
Add node names instead of node IDs to networkx graph

### DIFF
--- a/tdc/resource/primekg.py
+++ b/tdc/resource/primekg.py
@@ -33,8 +33,8 @@ class PrimeKG(KnowledgeGraph):
 
         G = nx.Graph()
         for i in self.df.relation.unique():
-            G.add_edges_from(self.df[self.df.relation == i][["x_id",
-                                                             "y_id"]].values,
+            G.add_edges_from(self.df[self.df.relation == i][["x_name",
+                                                             "y_name"]].values,
                              relation=i)
         return G
 

--- a/tdc/resource/primekg.py
+++ b/tdc/resource/primekg.py
@@ -33,9 +33,9 @@ class PrimeKG(KnowledgeGraph):
 
         G = nx.Graph()
         for i in self.df.relation.unique():
-            G.add_edges_from(self.df[self.df.relation == i][["x_name",
-                                                             "y_name"]].values,
-                             relation=i)
+            G.add_edges_from(
+                self.df[self.df.relation == i][["x_name", "y_name"]].values,
+                relation=i)
         return G
 
     def get_features(self, feature_type):


### PR DESCRIPTION
**Problem:** Each node id (`x_id` and `y_id`) is node type specific. For example, a node ID of "1" for a disease node is different from a node ID of "1" for a gene/protein node. This is (likely) not an issue for training a GNN. However, it can be an issue if users want to do network analysis on PrimeKG because the current `to_nx()` function does not consider node type.

**Solution:** Instead of adding pairs of node IDs as edges, add pairs of node names because they are unique.