### PR TITLE
pd.append -> pd.concat

### DIFF
--- a/tdc/utils/split.py
+++ b/tdc/utils/split.py
@@ -351,8 +351,8 @@ def create_group_split(train_val, seed, holdout_frac, group_column):
         train_val_temp = train_val[train_val[group_column] == i]
         np.random.seed(seed)
         msk = np.random.rand(len(train_val_temp)) < (1 - holdout_frac)
-        train_df = pd.concat([train_df,train_val_temp[msk]], axis=0)
-        val_df = pd.concat([val_df,train_val_temp[~msk]], axis=0)
+        train_df = pd.concat([train_df, train_val_temp[msk]], axis=0)
+        val_df = pd.concat([val_df, train_val_temp[~msk]], axis=0)
 
     return {
         "train": train_df.reset_index(drop=True),

--- a/tdc/utils/split.py
+++ b/tdc/utils/split.py
@@ -351,8 +351,8 @@ def create_group_split(train_val, seed, holdout_frac, group_column):
         train_val_temp = train_val[train_val[group_column] == i]
         np.random.seed(seed)
         msk = np.random.rand(len(train_val_temp)) < (1 - holdout_frac)
-        train_df = train_df.append(train_val_temp[msk])
-        val_df = val_df.append(train_val_temp[~msk])
+        train_df = pd.concat([train_df,train_val_temp[msk]], axis=0)
+        val_df = pd.concat([val_df,train_val_temp[~msk]], axis=0)
 
     return {
         "train": train_df.reset_index(drop=True),

--- a/tdc/version.py
+++ b/tdc/version.py
@@ -19,4 +19,4 @@
 # Dev branch marker is: 'X.Y.dev' or 'X.Y.devN' where N is an integer.
 # 'X.Y.dev0' is the canonical version of 'X.Y.dev'
 #
-__version__ = "1.0.7"  # pragma: no cover
+__version__ = "1.1.0"  # pragma: no cover


### PR DESCRIPTION
**Problem:** Pandas `append` has been deprecated since version 1.4 and has been removed since version 1.6. `create_group_split` still uses `pandas.append` to split the train_val set into the train and val sets.

**Solution:** Updates `create_group_split` to utilize `pandas.concat` to create the train and val sets.