### PR TITLE
Fixed splitting perturboutcome by cell_line

### DIFF
--- a/tdc/multi_pred/perturboutcome.py
+++ b/tdc/multi_pred/perturboutcome.py
@@ -159,7 +159,7 @@ class PerturbOutcome(CellXGeneTemplate):
                            split_to_unseen=False,
                            remove_unseen=True):
         df = self.get_data()
-        cell_line_groups = df.groupby("cell_line")
+        cell_line_groups = df.obs.groupby("cell_line")
         cell_line_splits = {}
         for cell_line, cell_line_group in cell_line_groups:
             control = cell_line_group[cell_line_group["perturbation"] ==


### PR DESCRIPTION
The example mentioned in the  PerturbOutcome page (https://tdcommons.ai/multi_pred_tasks/counterfactual) does not work.

The example reads:
```
from tdc.multi_pred.perturboutcome import PerturbOutcome
data = PerturbOutcome(name = 'scperturb_drug_SrivatsanTrapnell2020_sciplex2')
split = data.get_split()
```

This raises a `AttributeError: 'AnnData' object has no attribute 'groupby'` on the line `cell_line_groups = df.groupby("cell_line")`

I think this change should fix the error.