### PR TITLE
bump: relax `sklearn` requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ numpy>=1.26.4,<2.0.0
 openpyxl>=3.0.10,<4.0.0
 pandas>=2.1.4,<3.0.0
 requests>=2.31.0,<3.0.0
-scikit-learn==1.2.2
+scikit-learn>=1.2.2
 seaborn>=0.12.2,<1.0.0
 tqdm>=4.65.0,<5.0.0
 transformers==4.43.4


### PR DESCRIPTION
## Update Scikit-Learn Version to Resolve Integration Conflicts

The previously pinned Scikit-Learn version caused integration issues by conflicting with the project’s dependency requirements, resulting in errors due to non-overlapping version constraints. This PR updates the version constraint to allow compatibility with a broader range of dependencies while ensuring continued functionality. This change improves flexibility, reduces dependency conflicts, and streamlines integration within the project.

Resolves https://github.com/mims-harvard/TDC/issues/354
cc: @amva13