### PR TITLE
bump: relax `transformers` requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ requests>=2.31.0,<3.0.0
 scikit-learn>=1.2.2
 seaborn>=0.12.2,<1.0.0
 tqdm>=4.65.0,<5.0.0
-transformers==4.43.4
+transformers>=4.43.0,<4.51.0
 cellxgene-census==1.15.0
 gget>=0.28.4,<1.0.0
 pydantic>=2.6.3,<3.0.0


### PR DESCRIPTION
## Update Transformers Version to Ensure Compatibility

The previously pinned Transformers version caused integration issues by conflicting with the project’s dependency requirements, resulting in errors due to non-overlapping version constraints. This PR updates the version constraint to allow compatibility with a broader range of dependencies while ensuring continued functionality. By updating to Transformers 4.50.2, this change improves flexibility, reduces dependency conflicts, and streamlines integration within the project.

additional to #354
cc: @amva13